### PR TITLE
fix: add a custom deserializer to TaskDefinition

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ mod unit_tests {
     use crate::models::workflow::*;
     use crate::models::task::*;
     use crate::models::map::*;
+    use serde_json::json;
 
     #[test]
     fn create_workflow() {
@@ -37,4 +38,203 @@ mod unit_tests {
         assert_eq!(workflow.document.summary, summary);
     }
 
+    #[test]
+    fn test_for_loop_definition_each_field_deserialization() {
+        // This test verifies that ForLoopDefinition correctly deserializes "each"
+        let for_loop_json = serde_json::json!({
+            "each": "item",
+            "in": ".items"
+        });
+
+        let result: Result<ForLoopDefinition, _> = serde_json::from_value(for_loop_json);
+
+        match result {
+            Ok(for_loop) => {
+                assert_eq!(for_loop.each, "item", "The 'each' field should be 'item'");
+                assert_eq!(for_loop.in_, ".items", "The 'in' field should be '.items'");
+            }
+            Err(e) => {
+                panic!(
+                    "Failed to deserialize ForLoopDefinition with 'each' field: {}",
+                    e
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_for_task_deserialization() {
+        // This is a valid For task - it has a "for" field and a "do" field
+        let for_task_json = json!({
+            "for": {
+                "each": "item",
+                "in": ".items"
+            },
+            "do": [
+                {
+                    "processItem": {
+                        "call": "processFunction",
+                        "with": {
+                            "item": "${ .item }"
+                        }
+                    }
+                }
+            ]
+        });
+
+        let result: Result<TaskDefinition, _> = serde_json::from_value(for_task_json.clone());
+
+        match result {
+            Ok(TaskDefinition::For(for_def)) => {
+                assert_eq!(for_def.for_.each, "item");
+                assert_eq!(for_def.for_.in_, ".items");
+                assert_eq!(for_def.do_.entries.len(), 1);
+                let has_process_item = for_def
+                    .do_
+                    .entries
+                    .iter()
+                    .any(|entry| entry.contains_key("processItem"));
+                assert!(
+                    has_process_item,
+                    "For task should contain processItem subtask"
+                );
+            }
+            Ok(TaskDefinition::Do(_)) => {
+                panic!("For task incorrectly deserialized as DoTaskDefinition");
+            }
+            Ok(other) => {
+                panic!("For task deserialized as unexpected variant: {:?}", other);
+            }
+            Err(e) => {
+                panic!("Failed to deserialize For task: {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_do_task_deserialization() {
+        // This is a valid Do task
+        let do_task_json = json!({
+            "do": [
+                {
+                    "step1": {
+                        "call": "function1"
+                    }
+                },
+                {
+                    "step2": {
+                        "call": "function2"
+                    }
+                }
+            ]
+        });
+
+        let result: Result<TaskDefinition, _> = serde_json::from_value(do_task_json);
+
+        match result {
+            Ok(TaskDefinition::Do(do_def)) => {
+                assert_eq!(do_def.do_.entries.len(), 2);
+                let has_step1 = do_def
+                    .do_
+                    .entries
+                    .iter()
+                    .any(|entry| entry.contains_key("step1"));
+                let has_step2 = do_def
+                    .do_
+                    .entries
+                    .iter()
+                    .any(|entry| entry.contains_key("step2"));
+                assert!(has_step1, "Do task should contain step1");
+                assert!(has_step2, "Do task should contain step2");
+            }
+            Ok(other) => {
+                panic!("Do task deserialized as unexpected variant: {:?}", other);
+            }
+            Err(e) => {
+                panic!("Failed to deserialize Do task: {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_for_task_with_while_condition() {
+        // TestFor task with a while condition
+        let for_task_json = json!({
+            "for": {
+                "each": "user",
+                "in": ".users",
+                "at": "index"
+            },
+            "while": "${ .index < 10 }",
+            "do": [
+                {
+                    "notifyUser": {
+                        "call": "notifyUser",
+                        "with": {
+                            "user": "${ .user }",
+                            "index": "${ .index }"
+                        }
+                    }
+                }
+            ]
+        });
+
+        let result: Result<TaskDefinition, _> = serde_json::from_value(for_task_json.clone());
+
+        match result {
+            Ok(TaskDefinition::For(for_def)) => {
+                assert_eq!(for_def.for_.each, "user");
+                assert_eq!(for_def.for_.in_, ".users");
+                assert_eq!(for_def.for_.at, Some("index".to_string()));
+                assert_eq!(for_def.while_, Some("${ .index < 10 }".to_string()));
+                assert_eq!(for_def.do_.entries.len(), 1);
+            }
+            Ok(TaskDefinition::Do(_)) => {
+                panic!("For task incorrectly deserialized as DoTaskDefinition");
+            }
+            Ok(other) => {
+                panic!("For task deserialized as unexpected variant: {:?}", other);
+            }
+            Err(e) => {
+                panic!("Failed to deserialize For task with while: {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_serialization() {
+        // Create a ForTaskDefinition programmatically
+
+        let for_loop = ForLoopDefinition::new("item", ".collection", None, None);
+        let mut do_tasks = Map::new();
+        do_tasks.add(
+            "task1".to_string(),
+            TaskDefinition::Call(CallTaskDefinition::new("someFunction", None, None)),
+        );
+
+        let for_task = ForTaskDefinition::new(for_loop, do_tasks, None);
+        let task_def = TaskDefinition::For(for_task);
+
+        // Serialize to JSON
+        let json_str = serde_json::to_string(&task_def).expect("Failed to serialize");
+        println!("Serialized: {}", json_str);
+
+        // Deserialize back
+        let deserialized: TaskDefinition =
+            serde_json::from_str(&json_str).expect("Failed to deserialize");
+
+        // Should still be a For task
+        match deserialized {
+            TaskDefinition::For(for_def) => {
+                assert_eq!(for_def.for_.each, "item");
+                assert_eq!(for_def.for_.in_, ".collection");
+            }
+            TaskDefinition::Do(_) => {
+                panic!("After roundtrip serialization, For task became a Do task");
+            }
+            other => {
+                panic!("Unexpected variant after roundtrip: {:?}", other);
+            }
+        }
+    }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR proposes fixes for two issues that I have run into that I would like to see addressed:

Issue 1:

In the official Serverless Workflows spec, it is possible to define Do and For type tasks. Both of these tasks have the `do` keyword in their definition. The example in the reference is:

```json
document:
  dsl: '1.0.2'
  namespace: test
  name: for-example
  version: '0.1.0'
do:
  - checkup:
      for:
        each: pet
        in: .pets
        at: index
      while: .vet != null
      do:
        - waitForCheckup:
            listen:
              to:
                one:
                  with:
                    type: com.fake.petclinic.pets.checkup.completed.v2
            output:
              as: '.pets + [{ "id": $pet.id }]'  
```

Unfortunately the TaskDefinition enum in `task.rs` uses #[serde(untagged)], which causes issues when deserializing tasks that have overlapping fields, such as 'do' and 'for'.
Serde will attempt to deserialize into each variant in order, and since both 'do' and 'for' tasks contain a 'do' field, this can lead to incorrect deserialization.

```
/// Represents a value that can be any of the supported task definitions
#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
#[serde(untagged)]
pub enum TaskDefinition{
    ...
    /// Variant holding the definition of a 'do' task
    Do(DoTaskDefinition),
    /// Variant holding the definition of an 'emit' task
    Emit(EmitTaskDefinition),
    /// Variant holding the definition of a 'for' task
    For(ForTaskDefinition),
    ...
}
````

In the current code, because Do comes before For in the enum, a ForTaskDefinition will _always_ be deserialized to a DoTaskDefinition, because Do it comes first in the list.

This PR adds a custom `Deserializer` for `TaskDefinition`, which can handle the issue between For and Do. It first checks to see whether `for` exists in the task definition, and matches a `ForTaskDefinition` if that is the case. The `do` case is placed at the end, so that collisions are avoided. Other task types should remain unaffected.

I added unit tests to test that the fix works, and that the custom validator fixes the issue.

Issue 2:

There is a small bug in the ForLoopDefinition in `task.rs`:

```
    #[serde(rename = "emit")]
    pub each: String,
```

`"emit"` should be `"each"`. This typo causes deserialization to fail. This PR fixes the issue and the unit test `test_for_loop_definition_each_field_deserialization` validates the bug and the fix.