### PR TITLE
fix: update wait and set task syntax

### DIFF
--- a/builders/src/lib.rs
+++ b/builders/src/lib.rs
@@ -434,7 +434,12 @@ mod unit_tests {
                 .iter()
                 .any(|entry| entry.get(&set_task_name.to_string()).map_or(false, |task|{
                     if let TaskDefinition::Set(set_task) = task {
-                        set_task.set == set_task_variables.clone()
+                        match &set_task.set {
+                            serverless_workflow_core::models::task::SetValue::Map(map) => {
+                                map == &set_task_variables
+                            }
+                            _ => false
+                        }
                     }
                     else{
                         false
@@ -482,12 +487,12 @@ mod unit_tests {
                 .iter()
                 .any(|entry| entry.get(&wait_task_name.to_string()).map_or(false, |task| {
                     if let TaskDefinition::Wait(wait_task) = task {
-                        wait_task.duration == wait_duration
+                        wait_task.wait == wait_duration
                     } else {
                         false
                     }
                 })),
-            "Expected a task with key '{}' and a WaitTaskDefinition with 'duration'={}",
+            "Expected a task with key '{}' and a WaitTaskDefinition with 'wait'={}",
             wait_task_name,
             wait_duration);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a couple of inconsistencies between the spec and the sdk that I ran into:

1. The Wait Task has the property `wait` (https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#wait), but in the current code it is set to `duration`. This PR renames it to `wait` to align with the spec.

2.  The Run Task Script (https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#script-process) a. the spec defines a `stdin` property that is missing in the current code. This PR adds that property.
b. the spec defines arguments as a list of strings, but the current code has it defined as a `HashMap`. This PR updates it to a `Vec<String>` to match the spec.

3. The Set Task (https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#set) defines the `set` property as being either a `map` or a `string` type, with the string type being an expression. The current code defines it as a `HashMap`, making it impossible to define it as a string expression. This PR introduces a complex type `SetValue`, which can be either a `HashMap` or an `Expression`, adding support for either type.

**Special notes for reviewers**:
I tried to add useful unit tests to test and validate the new behavior.

**Additional information (if needed):**