### PR TITLE
fix: align container and extension definitions to the spec

### DIFF
--- a/core/src/models/extension.rs
+++ b/core/src/models/extension.rs
@@ -14,11 +14,11 @@ pub struct ExtensionDefinition{
     #[serde(rename = "when", skip_serializing_if = "Option::is_none")]
     pub when: Option<String>,
 
-    /// Gets/sets a name/definition map, if any, of the tasks to execute before the extended task
+    /// Gets/sets a name/definition list, if any, of the tasks to execute before the extended task
     #[serde(rename = "before", skip_serializing_if = "Option::is_none")]
     pub before: Option<Vec<HashMap<String, TaskDefinition>>>,
 
-    /// Gets/sets a name/definition map, if any, of the tasks to execute after the extended task
+    /// Gets/sets a name/definition list, if any, of the tasks to execute after the extended task
     #[serde(rename = "after", skip_serializing_if = "Option::is_none")]
     pub after: Option<Vec<HashMap<String, TaskDefinition>>>
 }

--- a/core/src/models/extension.rs
+++ b/core/src/models/extension.rs
@@ -16,10 +16,9 @@ pub struct ExtensionDefinition{
 
     /// Gets/sets a name/definition map, if any, of the tasks to execute before the extended task
     #[serde(rename = "before", skip_serializing_if = "Option::is_none")]
-    pub before: Option<HashMap<String, TaskDefinition>>,
+    pub before: Option<Vec<HashMap<String, TaskDefinition>>>,
 
     /// Gets/sets a name/definition map, if any, of the tasks to execute after the extended task
     #[serde(rename = "after", skip_serializing_if = "Option::is_none")]
-    pub after: Option<HashMap<String, TaskDefinition>>
-
+    pub after: Option<Vec<HashMap<String, TaskDefinition>>>
 }

--- a/core/src/models/task.rs
+++ b/core/src/models/task.rs
@@ -715,9 +715,11 @@ pub struct ContainerProcessDefinition{
     #[serde(rename = "environment", skip_serializing_if = "Option::is_none")]
     pub environment: Option<HashMap<String, String>>,
 
+    /// Gets/sets the data to pass to the process via stdin, if any
     #[serde(rename = "stdin", skip_serializing_if = "Option::is_none")]
     pub stdin: Option<String>,
 
+    /// Gets/sets a list of arguments, if any, to pass to the container (argv)
     #[serde(rename = "arguments", skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Vec<String>>,
 }

--- a/core/src/models/task.rs
+++ b/core/src/models/task.rs
@@ -715,16 +715,23 @@ pub struct ContainerProcessDefinition{
     #[serde(rename = "environment", skip_serializing_if = "Option::is_none")]
     pub environment: Option<HashMap<String, String>>,
 
+    #[serde(rename = "stdin", skip_serializing_if = "Option::is_none")]
+    pub stdin: Option<String>,
+
+    #[serde(rename = "arguments", skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<Vec<String>>,
 }
 impl ContainerProcessDefinition {
-    pub fn new(image: &str, name: Option<String>, command: Option<String>, ports: Option<HashMap<u16, u16>>, volumes: Option<HashMap<String, String>>, environment: Option<HashMap<String, String>>) -> Self{
+    pub fn new(image: &str, name: Option<String>, command: Option<String>, ports: Option<HashMap<u16, u16>>, volumes: Option<HashMap<String, String>>, environment: Option<HashMap<String, String>>, stdin: Option<String>, arguments: Option<Vec<String>>) -> Self{
         Self { 
             image: image.to_string(), 
             name,
             command, 
             ports, 
             volumes, 
-            environment
+            environment,
+            stdin,
+            arguments,
         }
     }
 }

--- a/core/src/models/workflow.rs
+++ b/core/src/models/workflow.rs
@@ -205,7 +205,7 @@ pub struct ComponentDefinitionCollection{
     #[serde(rename = "errors", skip_serializing_if = "Option::is_none")]
     pub errors: Option<HashMap<String, ErrorDefinition>>,
 
-    /// Gets/sets a name/value mapping of the workflow's extensions, if any
+    /// Gets/sets a list containing the workflow's extensions, if any
     #[serde(rename = "extensions", skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<HashMap<String, ExtensionDefinition>>>,
 

--- a/core/src/models/workflow.rs
+++ b/core/src/models/workflow.rs
@@ -207,7 +207,7 @@ pub struct ComponentDefinitionCollection{
 
     /// Gets/sets a name/value mapping of the workflow's extensions, if any
     #[serde(rename = "extensions", skip_serializing_if = "Option::is_none")]
-    pub extensions: Option<HashMap<String, ExtensionDefinition>>,
+    pub extensions: Option<Vec<HashMap<String, ExtensionDefinition>>>,
 
     /// Gets/sets a name/value mapping of the workflow's reusable functions
     #[serde(rename = "functions", skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This PR does two things:
1. This addresses the issue outlined in issue https://github.com/serverlessworkflow/specification/issues/1135, where the extensions in a workflow are supposed to be an array, as well as the before and after properties. This PR converts these HashMaps into Vec<HashMaps> to align with the spec.

I added a unit test that copies https://github.com/serverlessworkflow/specification/blob/main/examples/mock-service-extension.yaml verbatim and tries to create a `WorkflowDefinition` from it. This test fails without the fix, and succeeds with the fix.

2. The sdk is missing `stdin` and `arguments` from the ContainerProcessDefinition, despite being defined in the spec. This PR adds those properties to the type.

**Special notes for reviewers**:

**Additional information (if needed):**